### PR TITLE
Upgrade all services to JDK11.

### DIFF
--- a/discovery-service/pom.xml
+++ b/discovery-service/pom.xml
@@ -41,7 +41,7 @@
                 <version>1.2.0</version>
                 <configuration>
                     <imageName>kbastani/${project.name}</imageName>
-                    <baseImage>openjdk:11-jdk-oracle</baseImage>
+                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
                     <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
                     <!-- copy the service's jar file from target into the root directory of the image -->
                     <resources>

--- a/edge-service/pom.xml
+++ b/edge-service/pom.xml
@@ -49,7 +49,7 @@
 				<version>1.2.0</version>
 				<configuration>
 					<imageName>kbastani/${project.name}</imageName>
-					<baseImage>openjdk:11-jdk-oracle</baseImage>
+					<baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
 					<entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 					<!-- copy the service's jar file from target into the root directory of the image -->
 					<resources>

--- a/friend-service/pom.xml
+++ b/friend-service/pom.xml
@@ -85,7 +85,7 @@
                 <version>1.2.0</version>
                 <configuration>
                     <imageName>kbastani/${project.name}</imageName>
-                    <baseImage>openjdk:8-jre-alpine</baseImage>
+                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
                     <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
                     <!-- copy the service's jar file from target into the root directory of the image -->
                     <resources>

--- a/friend-service/src/main/java/io/example/FriendServiceApplication.java
+++ b/friend-service/src/main/java/io/example/FriendServiceApplication.java
@@ -3,7 +3,6 @@ package io.example;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +13,6 @@ import org.springframework.context.annotation.Configuration;
  * @author Kenny Bastani
  */
 @SpringBootApplication
-@EnableDiscoveryClient
 public class FriendServiceApplication {
 
     public static void main(String[] args) {

--- a/friend-service/src/main/resources/application.yml
+++ b/friend-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   profiles:
     active: development
 server:
-  port: ${PORT:${SERVER_PORT:0}}
+  port: ${PORT:${SERVER_PORT:8100}}
 ---
 spring:
   profiles: development

--- a/pom.xml
+++ b/pom.xml
@@ -13,14 +13,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.7.RELEASE</version>
+        <version>2.1.1.RELEASE</version>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
-        <spring-cloud.version>Finchley.SR2</spring-cloud.version>
+        <java.version>11</java.version>
+        <spring-cloud.version>Greenwich.M3</spring-cloud.version>
     </properties>
 
     <modules>
@@ -35,7 +35,10 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
     </dependencies>
 
@@ -51,4 +54,14 @@
         </dependencies>
     </dependencyManagement>
 
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/recommendation-service/pom.xml
+++ b/recommendation-service/pom.xml
@@ -103,7 +103,7 @@
                 <version>1.2.0</version>
                 <configuration>
                     <imageName>kbastani/${project.name}</imageName>
-                    <baseImage>openjdk:11-jdk-oracle</baseImage>
+                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
                     <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
                     <!-- copy the service's jar file from target into the root directory of the image -->
                     <resources>

--- a/recommendation-service/src/main/resources/application.yml
+++ b/recommendation-service/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
   profiles:
     active: docker
 server:
-  port: ${PORT:${SERVER_PORT:0}}
+  port: ${PORT:${SERVER_PORT:8110}}
 ---
 spring:
   profiles: development

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -81,7 +81,7 @@
                 <version>1.2.0</version>
                 <configuration>
                     <imageName>kbastani/${project.name}</imageName>
-                    <baseImage>openjdk:8-jre-alpine</baseImage>
+                    <baseImage>adoptopenjdk/openjdk11:jdk-11.28</baseImage>
                     <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
                     <!-- copy the service's jar file from target into the root directory of the image -->
                     <resources>

--- a/user-service/src/main/java/io/example/UserServiceApplication.java
+++ b/user-service/src/main/java/io/example/UserServiceApplication.java
@@ -2,7 +2,6 @@ package io.example;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +12,6 @@ import org.springframework.context.annotation.Configuration;
  * @author Kenny Bastani
  */
 @SpringBootApplication
-@EnableDiscoveryClient
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   profiles:
     active: development
 server:
-  port: ${PORT:${SERVER_PORT:0}}
+  port: ${PORT:${SERVER_PORT:8120}}
 ---
 spring:
   profiles: development


### PR DESCRIPTION
Two main changes here:

* Use Docker image from AdoptOpenJDK
* Update the Boot based services to 2.1.1, including Spring Cloud Greenwich.M3 which are all JDK 11 compatible
* Fix JAXB Dependencies für JDK 11

Only downside I see so far: Discovery client doesn't seem to like the random ports anymore (again, I guess (See for example https://github.com/spring-cloud/spring-cloud-netflix/issues/2732)

I have some more changes incoming based on that.